### PR TITLE
Wordcloud breaks when Whisper assigns null word output to a speaker

### DIFF
--- a/myutils.py
+++ b/myutils.py
@@ -239,6 +239,8 @@ def get_world_cloud(result, speakers_dict, path2figs="./data/logs"):
     figs = []
     for sp in speakers:
         words = ''.join([seg['text'] for seg in result['segments'] if seg.get('speaker')==sp])
+        if words == '':
+            continue
         wordcloud = WordCloud(max_font_size=40, background_color='white').generate(words)
         fig = plt.figure()
         plt.imshow(wordcloud, interpolation="bilinear")


### PR DESCRIPTION
Fixing a bug where pyannote detects phantom speakers, and whisper assigns zero words -- breaking wordcloud

![image](https://github.com/mave5/podalize/assets/4791393/5fcf5b77-8f58-48fd-b183-cd3db7401194)
